### PR TITLE
Separated `TimeTracker` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you need to, you can access the raw `mgo` session with `connection.Session`
 
 ### Create a Document
 
-Any struct can be used as a document as long as it satisfies the `Document` interface (`SetId(bson.ObjectId)`, `GetId() bson.ObjectId`). We recommend that you use the `DocumentBase` provided with Bongo, which implements that interface as well as the `NewTracker` and `TimeTracker` interfaces (to keep track of new/existing documents and created/modified timestamps). If you use the `DocumentBase` or something similar, make sure you use `bson:",inline"` otherwise you will get nested behavior when the data goes to your database.
+Any struct can be used as a document as long as it satisfies the `Document` interface (`SetId(bson.ObjectId)`, `GetId() bson.ObjectId`). We recommend that you use the `DocumentBase` provided with Bongo, which implements that interface as well as the `NewTracker`, `TimeCreatedTracker` and `TimeModifiedTracker` interfaces (to keep track of new/existing documents and created/modified timestamps). If you use the `DocumentBase` or something similar, make sure you use `bson:",inline"` otherwise you will get nested behavior when the data goes to your database.
 
 For example:
 

--- a/collection.go
+++ b/collection.go
@@ -38,8 +38,11 @@ type ValidationError struct {
 	Errors []error
 }
 
-type TimeTracker interface {
+type TimeCreatedTracker interface {
 	SetCreated(time.Time)
+}
+
+type TimeModifiedTracker interface {
 	SetModified(time.Time)
 }
 
@@ -131,10 +134,11 @@ func (c *Collection) Save(doc Document) error {
 	// Add created/modified time. Also set on the model itself if it has those fields.
 	now := time.Now()
 
-	if tt, ok := doc.(TimeTracker); ok {
-		if isNew {
-			tt.SetCreated(now)
-		}
+	if tt, ok := doc.(TimeCreatedTracker); ok && isNew {
+		tt.SetCreated(now)
+	}
+
+	if tt, ok := doc.(TimeModifiedTracker); ok {
 		tt.SetModified(now)
 	}
 


### PR DESCRIPTION
Separated `TimeTracker` into `TimeCreatedTracker` and `TimeModifiedTracker` so if we want we don't need to add Created and Deleted properties in the document.

Now we can implement each field separately and the it's still backward compatible