### PR TITLE
Added `GetCreated` and `GetModified`

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -39,10 +39,12 @@ type ValidationError struct {
 }
 
 type TimeCreatedTracker interface {
+	GetCreated() time.Time
 	SetCreated(time.Time)
 }
 
 type TimeModifiedTracker interface {
+	GetModified() time.Time
 	SetModified(time.Time)
 }
 

--- a/collection_test.go
+++ b/collection_test.go
@@ -122,11 +122,11 @@ func TestCollection(t *testing.T) {
 
 			err := conn.Collection("tests").Save(doc)
 			So(err, ShouldEqual, nil)
-			So(doc.Created.UnixNano(), ShouldEqual, doc.Modified.UnixNano())
+			So(doc.Created.UnixNano(), ShouldEqual, doc.GetModified().UnixNano())
 
 			err = conn.Collection("tests").Save(doc)
 			So(err, ShouldEqual, nil)
-			So(doc.Modified.UnixNano(), ShouldBeGreaterThan, doc.Created.UnixNano())
+			So(doc.Modified.UnixNano(), ShouldBeGreaterThan, doc.GetCreated().UnixNano())
 		})
 
 		Reset(func() {

--- a/documentBase.go
+++ b/documentBase.go
@@ -36,6 +36,14 @@ func (d *DocumentBase) SetCreated(t time.Time) {
 	d.Created = t
 }
 
+func (d *DocumentBase) GetCreated() time.Time {
+	return d.Created
+}
+
 func (d *DocumentBase) SetModified(t time.Time) {
 	d.Modified = t
+}
+
+func (d *DocumentBase) GetModified() time.Time {
+	return d.Modified
 }

--- a/documentBase.go
+++ b/documentBase.go
@@ -19,6 +19,7 @@ func (d *DocumentBase) SetIsNew(isNew bool) {
 	d.exists = !isNew
 }
 
+// Is the document new
 func (d *DocumentBase) IsNew() bool {
 	return !d.exists
 }
@@ -28,22 +29,27 @@ func (d *DocumentBase) GetId() bson.ObjectId {
 	return d.Id
 }
 
+// Sets the ID for the document
 func (d *DocumentBase) SetId(id bson.ObjectId) {
 	d.Id = id
 }
 
+// Set's the created date
 func (d *DocumentBase) SetCreated(t time.Time) {
 	d.Created = t
 }
 
+// Get the created date
 func (d *DocumentBase) GetCreated() time.Time {
 	return d.Created
 }
 
+// Sets the modified date
 func (d *DocumentBase) SetModified(t time.Time) {
 	d.Modified = t
 }
 
+// Get's the modified date
 func (d *DocumentBase) GetModified() time.Time {
 	return d.Modified
 }


### PR DESCRIPTION
Added `GetCreated` to `TimeCreatedTracker` and `GetModified` to `TimeModifiedTracker`    

There are cases where you need to access those functions to be able to build a more generic implementation. 